### PR TITLE
0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,9 @@ This file is used to list changes made in each version of the inspec_cron cookbo
 - inspec_cron Custom Resource
 - inspec_target Custom Resource
 - add support for InSpec package_source and version
+
+## 0.5.0
+
+- support a list of target nodes that all behave the same
+- no longer expect '/opt/inspec/bin/inspec' as the default path, set to '/opt/chef/embedded/bin/inspec'
+- added 'everything' test to verify default and targets recipes together

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,7 @@ default['inspec_cron']['token'] = if node.to_hash.dig('chef_client', 'config', '
 default['inspec_cron']['version'] = nil
 default['inspec_cron']['channel'] = :stable
 default['inspec_cron']['package_source'] = nil
-default['inspec_cron']['path'] = '/opt/inspec/bin/inspec'
+default['inspec_cron']['path'] = '/opt/chef/embedded/bin/inspec'
 
 # default cron times for unscheduled profiles
 default['inspec_cron']['cron']['minute'] = '0'
@@ -39,6 +39,8 @@ default['inspec_cron']['profiles'] = {}
 
 # defaults for targets
 default['inspec_cron']['targets'] = {}
+default['inspec_cron']['target_list'] = []
+default['inspec_cron']['target_profiles'] = []
 # defaults are oriented around SSH, other settings could be added
 default['inspec_cron']['targets_key'] = nil
 default['inspec_cron']['targets_password'] = nil

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -47,6 +47,12 @@ suites:
     verifier:
       inspec_tests:
         - test/integration/targets
+  - name: list
+    provisioner:
+      policyfile: policyfiles/list.rb
+    verifier:
+      inspec_tests:
+        - test/integration/list
   - name: install_chef
     provisioner:
       product_version: 14

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -72,3 +72,9 @@ suites:
     verifier:
       inspec_tests:
         - test/integration/install_package
+  - name: everything
+    provisioner:
+      policyfile: policyfiles/everything.rb
+    verifier:
+      inspec_tests:
+        - test/integration/everything

--- a/policyfiles/everything.rb
+++ b/policyfiles/everything.rb
@@ -1,0 +1,93 @@
+name 'everything'
+
+default_source :supermarket
+
+cookbook 'inspec_cron', path: '..'
+
+run_list 'inspec_cron::default', 'inspec_cron::targets'
+
+default['inspec_cron']['package_source'] = '/test/inspec-4.17.4-1.el7.x86_64.rpm'
+default['inspec_cron']['path'] = '/opt/inspec/bin/inspec'
+default['chef_client']['config']['data_collector.server_url'] = 'https://automate.example.com/data-collector/v0/'
+default['inspec_cron']['insecure'] = true
+default['inspec_cron']['targets_user'] = 'scanner'
+default['chef_client']['config']['data_collector.server_url'] = 'https://automate.example.com/data-collector/v0/'
+default['chef_client']['config']['data_collector.token'] = '35V9X1VO0VRSeUjukPmBsihvwXI='
+
+default['inspec_cron']['profiles'] = {
+  'linux-patch-baseline': {
+    'url': 'https://github.com/dev-sec/linux-patch-baseline/archive/0.4.0.zip',
+    'minute': '15',
+    'hour': '*/6',
+  },
+  'ssh-baseline': {
+    'url': 'https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz',
+    'minute': '45',
+  },
+  'uptime': {
+    'url': 'https://github.com/mattray/uptime-profile',
+  },
+}
+
+default['inspec_cron']['targets'] = {
+  '10.0.0.2': {
+    'key': '/tmp/test.id_rsa',
+    'profiles': {
+      'uptime': {
+        'url': 'https://github.com/mattray/uptime-profile',
+        'minute': '*/10',
+      },
+    },
+  },
+  '10.0.0.3': {
+    'password': 'testing',
+    'sudo': true,
+    'node_uuid': 'aaaaaaaa-3976-410f-83a1-22ab3b40638c',
+    'profiles': {
+      'linux-patch-baseline': {
+        'url': 'https://github.com/dev-sec/linux-patch-baseline/',
+      },
+      'uptime': {
+        'url': 'https://github.com/mattray/uptime-profile',
+        'minute': '*/5',
+      },
+    },
+  },
+  '10.0.0.4': {
+    'node_uuid': '11111111-2222-3333-4444-555555555555',
+    'password': 'testing',
+    'profiles': {
+      'uptime': {
+        'url': 'https://github.com/mattray/uptime-profile',
+        'minute': '*/7',
+      },
+      'ssh-baseline': {
+        'url': 'https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz',
+        'minute': '*/7',
+        'hour': '*/2',
+      },
+    },
+  },
+}
+
+# currently only support 1 list, a hash could be added in the future for multiple lists
+default['inspec_cron']['target_list'] =   ['10.0.0.12','10.0.0.13','10.0.0.14']
+default['inspec_cron']['target_settings'] = {
+                                             'environment': 'legacy',
+                                             'key': '/tmp/test.id_rsa',
+                                             'user': 'auditor',
+                                             'hour': '4'
+                                            }
+default['inspec_cron']['target_profiles'] = {
+  'linux-patch-baseline': {
+    'url': 'https://github.com/dev-sec/linux-patch-baseline/',
+    'minute': '*/7',
+    'hour': '*/2',
+  },
+  'ssh-baseline': {
+    'url': 'https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz'
+  },
+  'uptime': {
+    'url': 'https://github.com/mattray/uptime-profile'
+  }
+}

--- a/policyfiles/install_chef.rb
+++ b/policyfiles/install_chef.rb
@@ -5,3 +5,4 @@ default_source :supermarket
 cookbook 'inspec_cron', path: '..'
 
 run_list 'inspec_cron::install-inspec'
+default['inspec_cron']['path'] = '/opt/chef/embedded/bin/inspec'

--- a/policyfiles/install_package.rb
+++ b/policyfiles/install_package.rb
@@ -7,3 +7,4 @@ cookbook 'inspec_cron', path: '..'
 run_list 'inspec_cron::install-inspec'
 
 default['inspec_cron']['package_source'] = '/test/inspec-4.17.4-1.el7.x86_64.rpm'
+default['inspec_cron']['path'] = '/opt/inspec/bin/inspec'

--- a/policyfiles/install_version.rb
+++ b/policyfiles/install_version.rb
@@ -7,3 +7,4 @@ cookbook 'inspec_cron', path: '..'
 run_list 'inspec_cron::install-inspec'
 
 default['inspec_cron']['version'] = '4.12.0'
+default['inspec_cron']['path'] = '/opt/inspec/bin/inspec'

--- a/policyfiles/list.rb
+++ b/policyfiles/list.rb
@@ -1,0 +1,35 @@
+name 'list'
+
+default_source :supermarket
+
+cookbook 'inspec_cron', path: '..'
+
+run_list 'inspec_cron::targets'
+
+default['chef_client']['config']['data_collector.server_url'] = 'https://automate.example.com/data-collector/v0/'
+default['inspec_cron']['token'] = '35V9X1VO0VRSeUjukPmBsihvwXI='
+default['inspec_cron']['insecure'] = true
+
+default['inspec_cron']['targets_user'] = 'scanner'
+
+# currently only support 1 list, a hash could be added in the future for multiple lists
+default['inspec_cron']['target_list'] =   ['10.0.0.2','10.0.0.3','10.0.0.4']
+default['inspec_cron']['target_settings'] = {
+                                             'environment': 'legacy',
+                                             'key': '/tmp/test.id_rsa',
+                                             'user': 'auditor',
+                                             'hour': '4'
+                                            }
+default['inspec_cron']['target_profiles'] = {
+  'linux-patch-baseline': {
+    'url': 'https://github.com/dev-sec/linux-patch-baseline/',
+    'minute': '*/7',
+    'hour': '*/2',
+  },
+  'ssh-baseline': {
+    'url': 'https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz'
+  },
+  'uptime': {
+    'url': 'https://github.com/mattray/uptime-profile'
+  }
+}

--- a/policyfiles/targets.rb
+++ b/policyfiles/targets.rb
@@ -10,8 +10,6 @@ default['chef_client']['config']['data_collector.server_url'] = 'https://automat
 default['inspec_cron']['token'] = '35V9X1VO0VRSeUjukPmBsihvwXI='
 default['inspec_cron']['insecure'] = true
 
-default['inspec_cron']['version'] = '3.7.1'
-
 default['inspec_cron']['targets_user'] = 'test'
 
 default['inspec_cron']['targets'] = {

--- a/recipes/targets.rb
+++ b/recipes/targets.rb
@@ -3,10 +3,37 @@
 # Recipe:: targets
 #
 
-# each target has settings
+# individual target settings
 node['inspec_cron']['targets'].each do |target_name, settings|
   # and the profiles within the settings may have additional settings
   settings['profiles'].each do |profile_name, profile|
+    inspec_target target_name do
+      target_uuid settings['node_uuid']
+      target_environment settings['environment']
+      target_token settings['token']
+      target_inspec_json settings['inspec_json']
+      target_key settings['key']
+      target_password settings['password']
+      target_port settings['port']
+      target_protocol settings['protocol']
+      target_sudo settings['sudo']
+      target_user settings['user']
+      profile_name profile_name
+      profile_url profile['url']
+      minute profile['minute'] || settings['minute']
+      hour profile['hour'] || settings['hour']
+      day profile['day'] || settings['day']
+      weekday profile['weekday'] || settings['weekday']
+      month profile['month'] || settings['month']
+      inspec_path node['inspec_cron']['path']
+    end
+  end
+end
+
+# list of target machines
+node['inspec_cron']['target_list'].each do |target_name|
+  settings = node['inspec_cron']['target_settings']
+  node['inspec_cron']['target_profiles'].each do |profile_name, profile|
     inspec_target target_name do
       target_uuid settings['node_uuid']
       target_environment settings['environment']

--- a/test/integration/default/default_test.rb
+++ b/test/integration/default/default_test.rb
@@ -3,12 +3,12 @@
 # Inspec test for recipe inspec_cron::default
 
 describe crontab do
-  its('commands') { should include '/opt/inspec/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/archive/0.4.0.zip --json-config /etc/chef/inspec.json' }
-  its('commands') { should include '/opt/inspec/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz --json-config /etc/chef/inspec.json' }
-  its('commands') { should include '/opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile --json-config /etc/chef/inspec.json' }
+  its('commands') { should include '/opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/archive/0.4.0.zip --json-config /etc/chef/inspec.json' }
+  its('commands') { should include '/opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz --json-config /etc/chef/inspec.json' }
+  its('commands') { should include '/opt/chef/embedded/bin/inspec exec https://github.com/mattray/uptime-profile --json-config /etc/chef/inspec.json' }
 end
 
-describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/archive/0.4.0.zip --json-config /etc/chef/inspec.json') do
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/archive/0.4.0.zip --json-config /etc/chef/inspec.json') do
   its('minutes') { should cmp '15' }
   its('hours') { should cmp '*/6' }
   its('days') { should cmp '*' }
@@ -16,7 +16,7 @@ describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-se
   its('months') { should cmp '*' }
 end
 
-describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz --json-config /etc/chef/inspec.json') do
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz --json-config /etc/chef/inspec.json') do
   its('minutes') { should cmp '45' }
   its('hours') { should cmp '*' }
   its('days') { should cmp '*' }
@@ -24,7 +24,7 @@ describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-se
   its('months') { should cmp '*' }
 end
 
-describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile --json-config /etc/chef/inspec.json') do
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/mattray/uptime-profile --json-config /etc/chef/inspec.json') do
   its('minutes') { should cmp '0' }
   its('hours') { should cmp '*/4' }
   its('days') { should cmp '*' }

--- a/test/integration/everything/default_test.rb
+++ b/test/integration/everything/default_test.rb
@@ -1,0 +1,227 @@
+# # encoding: utf-8
+
+# Inspec test for recipe inspec_cron::default
+
+# inspec checks
+describe file('/opt/inspec/bin/inspec') do
+  it { should exist }
+end
+
+describe command('inspec') do
+  it { should exist }
+end
+
+describe command('inspec --version') do
+  its('stdout') { should match /^4.17.4$/ }
+end
+
+describe package('inspec') do
+  it { should be_installed }
+  its('version') { should eq '4.17.4-1.el7' }
+end
+
+describe directory('/etc/chef') do
+  it { should exist }
+end
+
+describe file('/etc/chef/inspec.json') do
+  it { should exist }
+end
+
+describe json('/etc/chef/inspec.json') do
+  its(%w(reporter automate environment)) { should eq 'local' }
+  its(%w(reporter automate insecure)) { should eq true }
+  its(%w(reporter automate stdout)) { should eq false }
+  its(%w(reporter automate node_uuid)) { should match /^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/ }
+  its(%w(reporter automate token)) { should eq '35V9X1VO0VRSeUjukPmBsihvwXI=' }
+  its(%w(reporter automate url)) { should eq 'https://automate.example.com/data-collector/v0/' }
+end
+
+describe directory('/etc/chef/targets') do
+  it { should exist }
+end
+
+%w(10.0.0.2 10.0.0.3 10.0.0.4 10.0.0.12 10.0.0.13 10.0.0.14).each do |target|
+  describe file("/etc/chef/targets/#{target}/node_uuid") do
+    it { should exist }
+  end
+
+  describe json("/etc/chef/targets/#{target}/inspec.json") do
+    its(%w(reporter automate insecure)) { should eq true }
+    its(%w(reporter automate node_name)) { should eq target }
+    its(%w(reporter automate node_uuid)) { should match /^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/ }
+    its(%w(reporter automate stdout)) { should eq false }
+    its(%w(reporter automate token)) { should eq '35V9X1VO0VRSeUjukPmBsihvwXI=' }
+    its(%w(reporter automate url)) { should eq 'https://automate.example.com/data-collector/v0/' }
+  end
+end
+
+# Chef Name: inspec-cron: everything-centos-7: linux-patch-baseline
+# 15 */6 * * * /opt/inspec/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/archive/0.4.0.zip --json-config /etc/chef/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/archive/0.4.0.zip --json-config /etc/chef/inspec.json') do
+  its('minutes') { should cmp '15' }
+  its('hours') { should cmp '*/6' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: everything-centos-7: ssh-baseline
+# 45 * * * * /opt/inspec/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz --json-config /etc/chef/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz --json-config /etc/chef/inspec.json') do
+  its('minutes') { should cmp '45' }
+  its('hours') { should cmp '*' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: everything-centos-7: uptime
+# 0 */12 * * * /opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile --json-config /etc/chef/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile --json-config /etc/chef/inspec.json') do
+  its('minutes') { should cmp '0' }
+  its('hours') { should cmp '*/12' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.2: uptime
+# */10 * * * * /opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://scanner@10.0.0.2 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.2/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://scanner@10.0.0.2 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.2/inspec.json') do
+  its('minutes') { should cmp '*/10' }
+  its('hours') { should cmp '*' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.3: linux-patch-baseline
+# 0 */12 * * * /opt/inspec/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://scanner@10.0.0.3 --port=22 --password=testing --sudo --json-config /etc/chef/targets/10.0.0.3/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://scanner@10.0.0.3 --port=22 --password=testing --sudo --json-config /etc/chef/targets/10.0.0.3/inspec.json') do
+  its('minutes') { should cmp '0' }
+  its('hours') { should cmp '*/12' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.3: uptime
+# */5 * * * * /opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://scanner@10.0.0.3 --port=22 --password=testing --sudo --json-config /etc/chef/targets/10.0.0.3/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://scanner@10.0.0.3 --port=22 --password=testing --sudo --json-config /etc/chef/targets/10.0.0.3/inspec.json') do
+  its('minutes') { should cmp '*/5' }
+  its('hours') { should cmp '*' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.4: uptime
+# */7 * * * * /opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://scanner@10.0.0.4 --port=22 --password=testing --json-config /etc/chef/targets/10.0.0.4/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://scanner@10.0.0.4 --port=22 --password=testing --json-config /etc/chef/targets/10.0.0.4/inspec.json') do
+  its('minutes') { should cmp '*/7' }
+  its('hours') { should cmp '*' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.4: ssh-baseline
+# */7 */2 * * * /opt/inspec/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://scanner@10.0.0.4 --port=22 --password=testing --json-config /etc/chef/targets/10.0.0.4/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://scanner@10.0.0.4 --port=22 --password=testing --json-config /etc/chef/targets/10.0.0.4/inspec.json') do
+  its('minutes') { should cmp '*/7' }
+  its('hours') { should cmp '*/2' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.12: linux-patch-baseline
+# */7 */2 * * * /opt/inspec/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://auditor@10.0.0.12 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.12/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://auditor@10.0.0.12 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.12/inspec.json') do
+  its('minutes') { should cmp '*/7' }
+  its('hours') { should cmp '*/2' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.12: ssh-baseline
+# * 4 * * * /opt/inspec/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://auditor@10.0.0.12 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.12/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://auditor@10.0.0.12 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.12/inspec.json') do
+  its('minutes') { should cmp '*' }
+  its('hours') { should cmp '4' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.12: uptime
+# * 4 * * * /opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://auditor@10.0.0.12 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.12/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://auditor@10.0.0.12 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.12/inspec.json') do
+  its('minutes') { should cmp '*' }
+  its('hours') { should cmp '4' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.13: linux-patch-baseline
+# */7 */2 * * * /opt/inspec/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://auditor@10.0.0.13 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.13/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://auditor@10.0.0.13 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.13/inspec.json') do
+  its('minutes') { should cmp '*/7' }
+  its('hours') { should cmp '*/2' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.13: ssh-baseline
+# * 4 * * * /opt/inspec/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://auditor@10.0.0.13 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.13/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://auditor@10.0.0.13 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.13/inspec.json') do
+  its('minutes') { should cmp '*' }
+  its('hours') { should cmp '4' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.13: uptime
+# * 4 * * * /opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://auditor@10.0.0.13 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.13/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://auditor@10.0.0.13 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.13/inspec.json') do
+  its('minutes') { should cmp '*' }
+  its('hours') { should cmp '4' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.14: linux-patch-baseline
+# */7 */2 * * * /opt/inspec/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://auditor@10.0.0.14 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.14/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://auditor@10.0.0.14 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.14/inspec.json') do
+  its('minutes') { should cmp '*/7' }
+  its('hours') { should cmp '*/2' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.14: ssh-baseline
+# * 4 * * * /opt/inspec/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://auditor@10.0.0.14 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.14/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://auditor@10.0.0.14 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.14/inspec.json') do
+  its('minutes') { should cmp '*' }
+  its('hours') { should cmp '4' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.14: uptime
+# * 4 * * * /opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://auditor@10.0.0.14 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.14/inspec.json
+describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://auditor@10.0.0.14 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.14/inspec.json') do
+  its('minutes') { should cmp '*' }
+  its('hours') { should cmp '4' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end

--- a/test/integration/inspec_json/conf_test.rb
+++ b/test/integration/inspec_json/conf_test.rb
@@ -14,6 +14,7 @@ describe json('/etc/chef/inspec.json') do
   its(%w(reporter automate environment)) { should eq 'local' }
   its(%w(reporter automate insecure)) { should eq true }
   its(%w(reporter automate stdout)) { should eq false }
+  its(%w(reporter automate node_uuid)) { should match /^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/ }
   its(%w(reporter automate token)) { should eq '35V9X1VO0VRSeUjukPmBsihvwXI=' }
   its(%w(reporter automate url)) { should eq 'https://automate.example.com/data-collector/v0/' }
 end

--- a/test/integration/install_chef/test.rb
+++ b/test/integration/install_chef/test.rb
@@ -2,6 +2,10 @@
 
 # Inspec test for recipe inspec_cron::install-inspec
 
+describe file('/opt/inspec/bin/inspec') do
+  it { should_not exist }
+end
+
 describe command('inspec') do
   it { should_not exist }
 end

--- a/test/integration/install_package/test.rb
+++ b/test/integration/install_package/test.rb
@@ -2,6 +2,10 @@
 
 # Inspec test for recipe inspec_cron::install-inspec
 
+describe file('/opt/inspec/bin/inspec') do
+  it { should exist }
+end
+
 describe command('inspec') do
   it { should exist }
 end

--- a/test/integration/install_version/test.rb
+++ b/test/integration/install_version/test.rb
@@ -2,6 +2,10 @@
 
 # Inspec test for recipe inspec_cron::install-inspec
 
+describe file('/opt/inspec/bin/inspec') do
+  it { should exist }
+end
+
 describe command('inspec') do
   it { should exist }
 end

--- a/test/integration/list/targets_test.rb
+++ b/test/integration/list/targets_test.rb
@@ -1,0 +1,137 @@
+# # encoding: utf-8
+
+# Inspec test for recipe inspec_cron::list
+
+describe directory('/etc/chef/targets') do
+  it { should exist }
+end
+
+%w(10.0.0.2 10.0.0.3 10.0.0.4).each do |target|
+  describe file("/etc/chef/targets/#{target}/node_uuid") do
+    it { should exist }
+  end
+
+  describe file("/etc/chef/targets/#{target}/inspec.json") do
+    it { should exist }
+  end
+end
+
+describe json('/etc/chef/targets/10.0.0.2/inspec.json') do
+  its(%w(reporter automate environment)) { should eq 'legacy' }
+  its(%w(reporter automate insecure)) { should eq true }
+  its(%w(reporter automate node_name)) { should eq '10.0.0.2' }
+  its(%w(reporter automate node_uuid)) { should match /^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/ }
+  its(%w(reporter automate stdout)) { should eq false }
+  its(%w(reporter automate token)) { should eq '35V9X1VO0VRSeUjukPmBsihvwXI=' }
+  its(%w(reporter automate url)) { should eq 'https://automate.example.com/data-collector/v0/' }
+end
+
+describe json('/etc/chef/targets/10.0.0.3/inspec.json') do
+  its(%w(reporter automate environment)) { should eq 'legacy' }
+  its(%w(reporter automate insecure)) { should eq true }
+  its(%w(reporter automate node_name)) { should eq '10.0.0.3' }
+  its(%w(reporter automate node_uuid)) { should match /^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/ }
+  its(%w(reporter automate stdout)) { should eq false }
+  its(%w(reporter automate token)) { should eq '35V9X1VO0VRSeUjukPmBsihvwXI=' }
+  its(%w(reporter automate url)) { should eq 'https://automate.example.com/data-collector/v0/' }
+end
+
+describe json('/etc/chef/targets/10.0.0.4/inspec.json') do
+  its(%w(reporter automate environment)) { should eq 'legacy' }
+  its(%w(reporter automate insecure)) { should eq true }
+  its(%w(reporter automate node_name)) { should eq '10.0.0.4' }
+  its(%w(reporter automate node_uuid)) { should match /^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/ }
+  its(%w(reporter automate stdout)) { should eq false }
+  its(%w(reporter automate token)) { should eq '35V9X1VO0VRSeUjukPmBsihvwXI=' }
+  its(%w(reporter automate url)) { should eq 'https://automate.example.com/data-collector/v0/' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.2: linux-patch-baseline
+# */7 */2 * * * /opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://auditor@10.0.0.2 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.2/inspec.json
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://auditor@10.0.0.2 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.2/inspec.json') do
+  its('minutes') { should cmp '*/7' }
+  its('hours') { should cmp '*/2' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.2: ssh-baseline
+# * 4 * * * /opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://auditor@10.0.0.2 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.2/inspec.json
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://auditor@10.0.0.2 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.2/inspec.json') do
+  its('minutes') { should cmp '*' }
+  its('hours') { should cmp '4' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.2: uptime
+# * 4 * * * /opt/chef/embedded/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://auditor@10.0.0.2 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.2/inspec.json
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://auditor@10.0.0.2 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.2/inspec.json') do
+  its('minutes') { should cmp '*' }
+  its('hours') { should cmp '4' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.3: linux-patch-baseline
+# */7 */2 * * * /opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://auditor@10.0.0.3 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.3/inspec.json
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://auditor@10.0.0.3 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.3/inspec.json') do
+  its('minutes') { should cmp '*/7' }
+  its('hours') { should cmp '*/2' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.3: ssh-baseline
+# * 4 * * * /opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://auditor@10.0.0.3 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.3/inspec.json
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://auditor@10.0.0.3 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.3/inspec.json') do
+  its('minutes') { should cmp '*' }
+  its('hours') { should cmp '4' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.3: uptime
+# * 4 * * * /opt/chef/embedded/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://auditor@10.0.0.3 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.3/inspec.json
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://auditor@10.0.0.3 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.3/inspec.json') do
+  its('minutes') { should cmp '*' }
+  its('hours') { should cmp '4' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.4: linux-patch-baseline
+# */7 */2 * * * /opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://auditor@10.0.0.4 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.4/inspec.json
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://auditor@10.0.0.4 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.4/inspec.json') do
+  its('minutes') { should cmp '*/7' }
+  its('hours') { should cmp '*/2' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.4: ssh-baseline
+# * 4 * * * /opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://auditor@10.0.0.4 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.4/inspec.json
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://auditor@10.0.0.4 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.4/inspec.json') do
+  its('minutes') { should cmp '*' }
+  its('hours') { should cmp '4' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end
+
+# Chef Name: inspec-cron: 10.0.0.4: uptime
+# * 4 * * * /opt/chef/embedded/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://auditor@10.0.0.4 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.4/inspec.json
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://auditor@10.0.0.4 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.4/inspec.json') do
+  its('minutes') { should cmp '*' }
+  its('hours') { should cmp '4' }
+  its('days') { should cmp '*' }
+  its('weekdays') { should cmp '*' }
+  its('months') { should cmp '*' }
+end

--- a/test/integration/targets/targets_test.rb
+++ b/test/integration/targets/targets_test.rb
@@ -20,6 +20,7 @@ describe json('/etc/chef/targets/10.0.0.2/inspec.json') do
   its(%w(reporter automate environment)) { should eq 'local' }
   its(%w(reporter automate insecure)) { should eq true }
   its(%w(reporter automate node_name)) { should eq '10.0.0.2' }
+  its(%w(reporter automate node_uuid)) { should match /^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/ }
   its(%w(reporter automate stdout)) { should eq false }
   its(%w(reporter automate token)) { should eq '35V9X1VO0VRSeUjukPmBsihvwXI=' }
   its(%w(reporter automate url)) { should eq 'https://automate.example.com/data-collector/v0/' }
@@ -33,6 +34,7 @@ describe json('/etc/chef/targets/10.0.0.3/inspec.json') do
   its(%w(reporter automate environment)) { should eq 'foo' }
   its(%w(reporter automate insecure)) { should eq true }
   its(%w(reporter automate node_name)) { should eq '10.0.0.3' }
+  its(%w(reporter automate node_uuid)) { should match /^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/ }
   its(%w(reporter automate stdout)) { should eq false }
   its(%w(reporter automate token)) { should eq 'vWswevpNZb7OXJ0jXF11TYxbHZE=' }
   its(%w(reporter automate url)) { should eq 'https://automate.example.com/data-collector/v0/' }
@@ -46,14 +48,15 @@ describe json('/etc/chef/targets/10.0.0.4/inspec.json') do
   its(%w(reporter automate environment)) { should eq 'local' }
   its(%w(reporter automate insecure)) { should eq true }
   its(%w(reporter automate node_name)) { should eq '10.0.0.4' }
+  its(%w(reporter automate node_uuid)) { should match /^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/ }
   its(%w(reporter automate stdout)) { should eq false }
   its(%w(reporter automate token)) { should eq '35V9X1VO0VRSeUjukPmBsihvwXI=' }
   its(%w(reporter automate url)) { should eq 'https://automate.example.com/data-collector/v0/' }
 end
 
 # # Chef Name: inspec-cron: 10.0.0.2: uptime
-# */10 * * * * /opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://test@10.0.0.2 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.2/inspec.json
-describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://test@10.0.0.2 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.2/inspec.json') do
+# */10 * * * * /opt/chef/embedded/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://test@10.0.0.2 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.2/inspec.json
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://test@10.0.0.2 --port=22 -i=/tmp/test.id_rsa --json-config /etc/chef/targets/10.0.0.2/inspec.json') do
   its('minutes') { should cmp '*/10' }
   its('hours') { should cmp '*' }
   its('days') { should cmp '*' }
@@ -62,8 +65,8 @@ describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/mattra
 end
 
 # Chef Name: inspec-cron: 10.0.0.3: linux-patch-baseline
-# 0 */12 * * * /opt/inspec/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://test@10.0.0.3 --port=22 --password=testing --sudo --json-config /etc/chef/targets/10.0.0.3/inspec.json
-describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://test@10.0.0.3 --port=22 --password=testing --sudo --json-config /etc/chef/targets/10.0.0.3/inspec.json') do
+# 0 */12 * * * /opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://test@10.0.0.3 --port=22 --password=testing --sudo --json-config /etc/chef/targets/10.0.0.3/inspec.json
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/linux-patch-baseline/ -t ssh://test@10.0.0.3 --port=22 --password=testing --sudo --json-config /etc/chef/targets/10.0.0.3/inspec.json') do
   its('minutes') { should cmp '0' }
   its('hours') { should cmp '*/12' }
   its('days') { should cmp '*' }
@@ -72,8 +75,8 @@ describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-se
 end
 
 # Chef Name: inspec-cron: 10.0.0.3: uptime
-# */5 * * * * /opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://test@10.0.0.3 --port=22 --password=testing --sudo --json-config /etc/chef/targets/10.0.0.3/inspec.json
-describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://test@10.0.0.3 --port=22 --password=testing --sudo --json-config /etc/chef/targets/10.0.0.3/inspec.json') do
+# */5 * * * * /opt/chef/embedded/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://test@10.0.0.3 --port=22 --password=testing --sudo --json-config /etc/chef/targets/10.0.0.3/inspec.json
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://test@10.0.0.3 --port=22 --password=testing --sudo --json-config /etc/chef/targets/10.0.0.3/inspec.json') do
   its('minutes') { should cmp '*/5' }
   its('hours') { should cmp '*' }
   its('days') { should cmp '*' }
@@ -82,8 +85,8 @@ describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/mattra
 end
 
 # Chef Name: inspec-cron: 10.0.0.4: uptime
-# */7 * * * * /opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://test@10.0.0.4 --port=22 --password=testing --json-config /etc/chef/targets/10.0.0.4/inspec.json
-describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://test@10.0.0.4 --port=22 --password=testing --json-config /etc/chef/targets/10.0.0.4/inspec.json') do
+# */7 * * * * /opt/chef/embedded/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://test@10.0.0.4 --port=22 --password=testing --json-config /etc/chef/targets/10.0.0.4/inspec.json
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/mattray/uptime-profile -t ssh://test@10.0.0.4 --port=22 --password=testing --json-config /etc/chef/targets/10.0.0.4/inspec.json') do
   its('minutes') { should cmp '*/7' }
   its('hours') { should cmp '*' }
   its('days') { should cmp '*' }
@@ -92,8 +95,8 @@ describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/mattra
 end
 
 # Chef Name: inspec-cron: 10.0.0.4: ssh-baseline
-# */7 */2 * * * /opt/inspec/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://test@10.0.0.4 --port=22 --password=testing --json-config /etc/chef/targets/10.0.0.4/inspec.json
-describe crontab.commands('/opt/inspec/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://test@10.0.0.4 --port=22 --password=testing --json-config /etc/chef/targets/10.0.0.4/inspec.json') do
+# */7 */2 * * * /opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://test@10.0.0.4 --port=22 --password=testing --json-config /etc/chef/targets/10.0.0.4/inspec.json
+describe crontab.commands('/opt/chef/embedded/bin/inspec exec https://github.com/dev-sec/ssh-baseline/archive/2.3.0.tar.gz -t ssh://test@10.0.0.4 --port=22 --password=testing --json-config /etc/chef/targets/10.0.0.4/inspec.json') do
   its('minutes') { should cmp '*/7' }
   its('hours') { should cmp '*/2' }
   its('days') { should cmp '*' }


### PR DESCRIPTION
- support a list of target nodes that all behave the same
- no longer expect '/opt/inspec/bin/inspec' as the default path, set to '/opt/chef/embedded/bin/inspec'
- added 'everything' test to verify default and targets recipes together
